### PR TITLE
#860q00kp7 : Update token names

### DIFF
--- a/lib/stas.js
+++ b/lib/stas.js
@@ -310,21 +310,21 @@ function getStasScript (destinationPublicKeyHash, redemptionPublicKey, data, isS
   protocol = protocol.toLowerCase();
   const redemptionPublicKeyHash = bsv.crypto.Hash.sha256ripemd160(redemptionPublicKey.toBuffer()).toString('hex')
   let script
-  if (protocol === 'stas'){
+  if (protocol === 'stas' || protocol === 'stas-0'){
     script = stasV2.replace('[destinationPublicKeyHash]', destinationPublicKeyHash).replace('[redemptionPublicKeyHash]', redemptionPublicKeyHash)
   }
-  if(protocol === 'stas50'){
+  if(protocol === 'stas50' || protocol === 'stas-50'){
     script = stas50V1.replace('[destinationPublicKeyHash]', destinationPublicKeyHash).replace('[redemptionPublicKeyHash]', redemptionPublicKeyHash)
   }
-  if(protocol === 'stasappend'){
+  if(protocol === 'stasappend' || protocol === 'stas-789'){
     script = stasAppendDataV1.replace('[destinationPublicKeyHash]', destinationPublicKeyHash).replace('[redemptionPublicKeyHash]', redemptionPublicKeyHash)
   }
-  if(protocol === 'stasft'){
+  if(protocol === 'stasft' || protocol === 'stas-20'){
     script = stasFtData.replace('[destinationPublicKeyHash]', destinationPublicKeyHash).replace('[redemptionPublicKeyHash]', redemptionPublicKeyHash)
   }
 
   let asm = ''
-  if(protocol === 'stas' || protocol === 'stas50'){
+  if(protocol === 'stas' || protocol === 'stas50' || protocol === 'stas-0' || protocol === 'stas-50'){
     if (isSplittable) {
       asm += '00 '
     } else {


### PR DESCRIPTION
Token Naming Update for "protocol" variable

Dynamic changes allows previous token names as well.

STAS-0 (previously STAS)
STAS-20 (previosuly STASFT)
STAS-789 (previously STASAPPEND)
STAS-50 (previously STAS50)

Changes are only for input variables as this is all that is required for functionality chaanges.
Successfully locally tested on all tokens and token name variations
NOTE : The NEW STAS library will only contain the new token names and references 

https://app.clickup.com/t/860q00kp7