### PR TITLE
#860q64t5z : Fee Calc adjustment for appended data

### DIFF
--- a/lib/stas.js
+++ b/lib/stas.js
@@ -10,7 +10,8 @@ const {
   reverseEndian,
   asciiToHex,
   MIN_SYMBOL_SIZE,
-  MAX_SYMBOL_SIZE
+  MAX_SYMBOL_SIZE,
+  toBytes,
 } = require('./utils')
 
 /*
@@ -149,8 +150,8 @@ function handleChange (tx, publicKey, appendData) {
 
   // Calculate the fees required...
   // Of the 3 outputs they will always have minimum OP_FALSE OF_FALSE (2 bytes) hence 2 x 3 = 6.  If there is an output it could take up 28 more bytes...
-  let appendDataCost = 0
-  appendData ? appendDataCost += bsv.Script.fromASM(asciiToHex(appendData)).toHex().length : appendDataCost
+ 
+  let appendDataCost = appendData ? Math.ceil(parseInt(toBytes(JSON.stringify(appendData)).length)) + 26 : 0
   let txSizeInBytes = tx.toBuffer().length + 6 + (tx.outputs.length * 28) + 9 + 33 + preimageLen + image.buf.length + 1 + 72 + 1 + 33 + appendDataCost
   txSizeInBytes += ((tx.inputs.length - 1) * P2PKH_UNLOCKING_SCRIPT_BYTES)
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,6 +144,17 @@ function nthIndex(str, pat, n) {
 	return i;
 }
 
+// convert string to buffer bytes
+function toBytes(text) {
+  const buffer = Buffer.from(text, 'utf8');
+  const result = Array(buffer.length);
+  for (let i = 0; i < buffer.length; i++) {
+    result[i] = buffer[i];
+  }
+  return buffer;
+};
+
+
 module.exports = {
   numberToLESM,
   replaceAll,
@@ -159,5 +170,6 @@ module.exports = {
   MAX_SYMBOL_SIZE,
   hexToAscii,
   asciiToHex,
-  nthIndex
+  nthIndex,
+  toBytes,
 }


### PR DESCRIPTION
Previous code was more generous to the miners by giving a bit more in fees. This was causing issues with our backend code that only allows for a 5 satoshi buffer over the exact cost of the transaction. Rather than increasing our buffer for fees we adjust the STAS library code to be more accurate. 

The change includes adding in a bytes conversion for the data string value to get a more accurate size and costing.
Testing video provided to back end team for verfication in ticket 
https://app.clickup.com/t/860q64t5z