### PR TITLE
#860qntvby : return tx object instead of hex

### DIFF
--- a/lib/contractWithCallback.js
+++ b/lib/contractWithCallback.js
@@ -97,7 +97,7 @@ function contractWithCallback (publicKey, inputUtxos, paymentUtxos, paymentPubli
   }
   ownerSignCallback(tx)
 
-  return tx.serialize(true)
+  return tx
 }
 
 module.exports = contractWithCallback

--- a/lib/issueWithCallback.js
+++ b/lib/issueWithCallback.js
@@ -127,7 +127,7 @@ function issueWithCallback (publicKey, issueInfo, contractUtxo, paymentUtxo, pay
     input.setScript(unlockingScript)
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 // make sure issueInfo array contains the required objects

--- a/lib/mergeSplitWithCallback.js
+++ b/lib/mergeSplitWithCallback.js
@@ -170,7 +170,7 @@ function mergeSplitWithCallback (tokenOwnerPublicKey, mergeUtxos, destination1Ad
     }
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 function handleChangeForMerge (tx, extraDataBytes, publicKey) {

--- a/lib/mergeWithCallback.js
+++ b/lib/mergeWithCallback.js
@@ -188,7 +188,7 @@ async function mergeWithCallback (tokenOwnerPublicKey, mergeUtxos, destinationAd
     }
   }
 
-  return tx.serialize(true)
+  return tx
 }
 
 function handleChangeForMerge (tx, extraDataBytes, publicKey) {

--- a/lib/redeemSplitWithCallback.js
+++ b/lib/redeemSplitWithCallback.js
@@ -122,7 +122,7 @@ function redeemSplitWithCallback (tokenOwnerPublicKey, contractPublicKey, stasUt
     }
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 module.exports = redeemSplitWithCallback

--- a/lib/redeemWithCallback.js
+++ b/lib/redeemWithCallback.js
@@ -103,7 +103,7 @@ function redeemWithCallback (tokenOwnerPublicKey, contractPublicKey, stasUtxo, p
     }
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 module.exports = redeemWithCallback

--- a/lib/splitWithCallback.js
+++ b/lib/splitWithCallback.js
@@ -103,7 +103,7 @@ function splitWithCallback (tokenOwnerPublicKey, stasUtxo, splitDestinations, pa
     }
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 module.exports = splitWithCallback

--- a/lib/swap.js
+++ b/lib/swap.js
@@ -333,7 +333,7 @@ function createSwapOffer (makerPrivateKey, makerInputUTXO, wantedInfo) {
       tx.inputs[1].setScript(takerUnlockScript)
       tx.inputs[2].setScript(paymentUnlockScript)
     
-      return tx.serialize(true)
+      return tx
     }
 /*
 
@@ -697,7 +697,7 @@ function acceptUnsignedSwapOffer (offerTxHex, makerInputTxHex,
   tx.inputs[1].setScript(takerUnlockScript)
   tx.inputs[2].setScript(paymentUnlockScript)
 
-  return tx.serialize(true)
+  return tx
 }
 
 // here the taker is supplying a p2pkh utxo
@@ -776,7 +776,7 @@ function acceptUnsignedNativeSwapOffer (offerTxHex, takerInputInfo, makerInputTx
   tx.inputs[1].setScript(takerUnlockScript)
   tx.inputs[2].setScript(paymentUnlockScript)
 
-  return tx.serialize(true)
+  return tx
 }
 
 function makerSignSwapOffer (offerTxHex, makerInputTxHex, takerInputTx, makerPrivateKey, takerPublicKeyHash, paymentPublicKeyHash, paymentUtxo) {
@@ -816,7 +816,7 @@ function makerSignSwapOffer (offerTxHex, makerInputTxHex, takerInputTx, makerPri
   }
   tx.inputs[0].setScript(makerUnlockScript)
 
-  return tx.serialize(true)
+  return tx
 }
 /*
 Depricated: don't use allInOneSwap

--- a/lib/transferWithCallback.js
+++ b/lib/transferWithCallback.js
@@ -126,7 +126,7 @@ function transferWithCallback (tokenOwnerPublicKey, stasUtxo, destinationAddress
     }
   })
 
-  return tx.serialize(true)
+  return tx
 }
 
 module.exports = transferWithCallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stas-js",
-  "version": "1.2.4",
+  "version": "1.2.8",
   "description": "This library will create various types of STAS token transactions that add token functionality to the BSV blockchain.",
   "main": "index.js",
   "module": "dist/index",


### PR DESCRIPTION
All functions will return transaction object instead of hexadecimal format with the exception of the create swap offer function as this is not broadcasted but only provided as the transaction to be used in the atomic swap.

https://app.clickup.com/t/860qntvby