### PR TITLE
Bug Fix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,9 +107,9 @@ function addressToPubkeyhash (addr) {
 }
 
 function reverseEndian (str) {
-  const num = new BN(str, 'hex')
-  const buf = num.toBuffer()
-  return buf.toString('hex').match(/.{2}/g).reverse().join('')
+  const buffer = Buffer.from(str, 'hex');
+  const reversedHex = [...buffer].reverse().map(byte => byte.toString(16).padStart(2, '0')).join('');
+  return reversedHex;
 }
 
 function bitcoinToSatoshis (amount) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stas-js",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "This library will create various types of STAS token transactions that add token functionality to the BSV blockchain.",
   "main": "index.js",
   "module": "dist/index",


### PR DESCRIPTION
Fix reversed Txid hex bug. In cases where the txid contains leading "00", that value is ignored by the toBuffer() function resulting in an unlocking script error.